### PR TITLE
some small padding and margin changes on buttons and cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
 <body class="content">
     <header class="flex justify-between py-8 px-4 bg-green-500">
-        <div class="w-7/12">
+        <div class="w-7/12 flex-wrap">
             <div>
                 <h1 class="font-extrabold text-5xl">Nutrition Helper</h1>
                 <p class="pt-4 font-medium">
@@ -30,7 +30,7 @@
         </div>
 
         <!--search history-->
-        <div class="w-5/12 px-4" id="history">
+        <div class="w-5/12 px-4 flex-wrap" id="history">
             <h2 class="font-bold text-3xl text-center">History</h2>
             <div id="history-button-container" class="grid grid-cols-1 pt-4">
 
@@ -45,8 +45,8 @@
                 <h2 class="font-bold text-3xl">Food Search Results:</h2>
                 <div class="w-3/12 self-center px-4 font-medium">
                     <form id="search-form">
-                        <input type="text" placeholder="Enter Food" name="search" id="search" class="form-input" />
-                        <button type="submit" class="py-2 px-4 text-white font-semibold bg-green-700 rounded-full">
+                        <input type="text" placeholder="Enter Food" name="search" id="search" class="form-input py-2 px-4 rounded-full" />
+                        <button type="submit" class="py-2 px-8 mx-4 text-white font-semibold bg-green-700 rounded-full">
                             Search
                         </button>
                     </form>
@@ -61,15 +61,15 @@
 
         <section class="py-8 px-4 bg-green-600 border-b-4 border-black" id="supplies-container">
             <!-- search store form cotainer -->
-            <div class="pb-6 flex justify-items-center">
+            <div class="pb-6 mb-2 flex justify-items-center">
                 <h2 class="font-bold text-3xl">
                     Find Nearby Stores For All Your Supplies:
                 </h2>
                 <div class="w-3/12 self-center px-4 font-medium">
                     <form id="search-zip-form">
                         <input type="text" placeholder="Enter Zipcode" name="search-zip" id="search-zip"
-                            class="form-input" />
-                        <button type="submit" id="zip-search-button" class="py-2 px-4 text-white font-semibold bg-green-700 rounded-full">
+                            class="form-input py-2 px-4 my-2 rounded-full" />
+                        <button type="submit" id="zip-search-button" class="py-2 px-8 mx-4 my-2 text-white font-semibold bg-green-700 rounded-full">
                             Search
                         </button>
                     </form>
@@ -83,7 +83,7 @@
         </section>
     </main>
 
-    <footer class="flex bottom-0 justify-center p-8 bg-green-800 text-white font-medium">
+    <footer class="flex bottom-0 justify-center p-8 bg-green-1000 text-white font-medium">
         <h2 class="px-4">Made By Group 4</h2>
         <div class="px-4">&copy; Nutrition Helper</div>
     </footer>

--- a/js/script.js
+++ b/js/script.js
@@ -142,7 +142,7 @@ var findStores = function (zipCode) {
 
                     // div for store card content
                     var storeCardContentDivEl= document.createElement("div");
-                    storeCardContentDivEl.className= "block p-6 rounded-lg shadow-lg bg-white max-w-sm";
+                    storeCardContentDivEl.className= "block p-2 rounded-lg shadow-lg bg-white max-w-sm";
                     storeCardDivEl.appendChild(storeCardContentDivEl);
 
                     //store card name
@@ -159,14 +159,14 @@ var findStores = function (zipCode) {
 
                     //list item address
                     var addressListItemEl = document.createElement("li");
-                    addressListItemEl.className= "px-6";
+                    addressListItemEl.className= "px-2";
                     var address = data.resourceSets[0].resources[i].Address.formattedAddress;
                     addressListItemEl.textContent= address;
                     storeCardListEl.appendChild(addressListItemEl);
 
                     //list item phone #
                     var phoneListItemEl = document.createElement("li");
-                    phoneListItemEl.className= "px-6";
+                    phoneListItemEl.className= "px-2";
                     var phoneNumber = data.resourceSets[0].resources[i].PhoneNumber;
                     phoneListItemEl.textContent= phoneNumber
                     storeCardListEl.appendChild(phoneListItemEl);


### PR DESCRIPTION
I rounded and added padding to the search fields so they more closely resemble the search buttons which gives a softer look.

I changed the padding on the address and phone number for the store cards from px-6 on lines 162 and 169 of the script.js file (which was the same as the nutrition content on the food cards) to px-2 as well as the padding on line 145 in the cards themselves from p-4 to p-2 because the addresses are longer than the food content and it was making those cards much wider than the food cards. Short of being able to separate the city, state and zip onto a second line (which I briefly pursued but felt wasn’t entirely necessary for MVP) I think this is the best quick option for begin able to make them more visibly separate cards .

We definitely still need to get the responsiveness done because right now the cards just kinda smoosh together rather than wrapping on smaller screens.
